### PR TITLE
Added MoreIota dependent patterns

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ subprojects {
 //            mappings "net.fabricmc:yarn:$rootProject.yarn_mappings:v2"
 //            mappings file("${rootProject.rootDir}/override.tiny")
 //        }
+
+        // Used by MoreIotas
+        implementation group: "org.jblas", name: "jblas", version: "1.2.5"
     }
 
     java {

--- a/challenges.md
+++ b/challenges.md
@@ -1,8 +1,8 @@
 ## Tech's Challenges
 *A personal To-Do List for TechTastic*
-* [ ] Boatwright's Prfn. (MoreIotas)
+* [x] Boatwright's Prfn. (MoreIotas)
     * Get the slug of a Ship
-*[ ] Boatwright's Dstl. (MoreIotas)
+* [x] Boatwright's Dstl. (MoreIotas)
     * Sets the slug of a Ship
 
 * [ ] Bearings Purification (Complex Hex)
@@ -11,9 +11,9 @@
     * Sets the rotation of a Ship from a Quaternion
         * Check if Quaternion is correct before use
 
-* [ ] Windward Purification (MoreIotas)
+* [x] Windward Purification (MoreIotas)
     * Gets the Ship-To-World Matrix
-* [ ] Leeward Purification (MoreIotas)
+* [x] Leeward Purification (MoreIotas)
     * Gets the World-To-Ship Matrix
 
 * Hexed Ships

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -21,4 +21,5 @@ dependencies {
     modCompileOnly "vazkii.patchouli:Patchouli:${rootProject.patchouli_version}-FABRIC"
     modCompileOnly "at.petra-k.hexcasting:hexcasting-common-1.20.1:${rootProject.hexcasting_version}"
     modCompileOnly files("${rootProject.rootDir}/libs/hexal-fabric-1.20.1-0.3.0-2.jar")
+    modCompileOnly files("${rootProject.rootDir}/libs/moreiotas-common-1.20.1-0.1.0-3.jar")
 }

--- a/common/src/main/java/net/walksanator/hexxyskies/casting/patterns/OpShipGetSlug.kt
+++ b/common/src/main/java/net/walksanator/hexxyskies/casting/patterns/OpShipGetSlug.kt
@@ -1,0 +1,18 @@
+package net.walksanator.hexxyskies.casting.patterns
+
+import at.petrak.hexcasting.api.casting.castables.ConstMediaAction
+import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
+import at.petrak.hexcasting.api.casting.iota.Iota
+import at.petrak.hexcasting.api.casting.iota.NullIota
+import net.walksanator.hexxyskies.getShip
+import ram.talia.moreiotas.api.casting.iota.StringIota
+
+object OpShipGetSlug: ConstMediaAction {
+    override val argc: Int
+        get() = 1
+
+    override fun execute(args: List<Iota>, env: CastingEnvironment): List<Iota> {
+        val slug = args.getShip(0, env.world, argc).slug ?: return listOf(NullIota())
+        return listOf(StringIota.make(slug))
+    }
+}

--- a/common/src/main/java/net/walksanator/hexxyskies/casting/patterns/OpShipSetSlug.kt
+++ b/common/src/main/java/net/walksanator/hexxyskies/casting/patterns/OpShipSetSlug.kt
@@ -1,0 +1,23 @@
+package net.walksanator.hexxyskies.casting.patterns
+
+import at.petrak.hexcasting.api.casting.castables.ConstMediaAction
+import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
+import at.petrak.hexcasting.api.casting.iota.Iota
+import at.petrak.hexcasting.api.casting.iota.NullIota
+import net.walksanator.hexxyskies.casting.iotas.ShipIota
+import net.walksanator.hexxyskies.getShip
+import net.walksanator.hexxyskies.ship.getShipDataHolder
+import ram.talia.moreiotas.api.getString
+
+object OpShipSetSlug: ConstMediaAction {
+    override val argc: Int
+        get() = 2
+
+    override fun execute(args: List<Iota>, env: CastingEnvironment): List<Iota> {
+        val slug = args.getString(0, argc)
+        val ship = args.getShip(1, env.world, argc)
+        if (ship.getShipDataHolder().cloaked) return listOf(NullIota())
+        ship.slug = slug
+        return listOf(ShipIota(ship.id, ship.slug))
+    }
+}

--- a/common/src/main/java/net/walksanator/hexxyskies/casting/patterns/OpShipToWorldMatrix.kt
+++ b/common/src/main/java/net/walksanator/hexxyskies/casting/patterns/OpShipToWorldMatrix.kt
@@ -1,0 +1,18 @@
+package net.walksanator.hexxyskies.casting.patterns
+
+import at.petrak.hexcasting.api.casting.castables.ConstMediaAction
+import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
+import at.petrak.hexcasting.api.casting.iota.Iota
+import net.walksanator.hexxyskies.getShip
+import ram.talia.moreiotas.api.casting.iota.MatrixIota
+
+object OpShipToWorldMatrix: ConstMediaAction {
+    override val argc: Int
+        get() = 1
+
+    override fun execute(args: List<Iota>, env: CastingEnvironment): List<Iota> {
+        val ship = args.getShip(0, env.world, argc)
+        val matrix = ship.transform.shipToWorld.toDoubleMatrix()
+        return listOf(MatrixIota(matrix))
+    }
+}

--- a/common/src/main/java/net/walksanator/hexxyskies/casting/patterns/OpWorldToShipMatrix.kt
+++ b/common/src/main/java/net/walksanator/hexxyskies/casting/patterns/OpWorldToShipMatrix.kt
@@ -1,0 +1,30 @@
+package net.walksanator.hexxyskies.casting.patterns
+
+import at.petrak.hexcasting.api.casting.castables.ConstMediaAction
+import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
+import at.petrak.hexcasting.api.casting.iota.Iota
+import net.walksanator.hexxyskies.getShip
+import org.jblas.DoubleMatrix
+import org.joml.Matrix4dc
+import ram.talia.moreiotas.api.casting.iota.MatrixIota
+
+object OpWorldToShipMatrix: ConstMediaAction {
+    override val argc: Int
+        get() = 1
+
+    override fun execute(args: List<Iota>, env: CastingEnvironment): List<Iota> {
+        val ship = args.getShip(0, env.world, argc)
+        val matrix = ship.transform.worldToShip.toDoubleMatrix()
+        return listOf(MatrixIota(matrix))
+    }
+}
+
+fun Matrix4dc.toDoubleMatrix(): DoubleMatrix {
+    val matrix = DoubleMatrix(4, 4)
+    for (row in 0..3) {
+        for (col in 0..3) {
+            matrix.put(row, col, this[col, row])
+        }
+    }
+    return matrix
+}

--- a/common/src/main/java/net/walksanator/hexxyskies/casting/patterns/PatternRegistry.kt
+++ b/common/src/main/java/net/walksanator/hexxyskies/casting/patterns/PatternRegistry.kt
@@ -108,6 +108,32 @@ object PatternRegistry {
         OpShipRaycast
     )}
 
+    val SHIP_SLUG_GET = if (Platform.isModLoaded("moreiotas")) {
+        REGISTRY.register("ship_slug_get") { ActionRegistryEntry(
+            HexPattern.fromAngles("wawwwaqwa", HexDir.EAST),
+            OpShipGetSlug
+        )}
+    } else {null}
+    val SHIP_SLUG_SET = if (Platform.isModLoaded("moreiotas")) {
+        REGISTRY.register("ship_slug_set") { ActionRegistryEntry(
+            HexPattern.fromAngles("wawadwedw", HexDir.EAST),
+            OpShipSetSlug
+        )}
+    } else {null}
+
+    val WORLD_TO_SHIP_MATRIX = if (Platform.isModLoaded("moreiotas")) {
+        REGISTRY.register("world_to_ship_matrix") { ActionRegistryEntry(
+            HexPattern.fromAngles("wawwwaeawae", HexDir.EAST),
+            OpWorldToShipMatrix
+        )}
+    } else {null}
+    val SHIP_TO_WORLD_MATRIX = if (Platform.isModLoaded("moreiotas")) {
+        REGISTRY.register("ship_to_world_matrix") { ActionRegistryEntry(
+            HexPattern.fromAngles("wawqqdwdqdw", HexDir.EAST),
+            OpShipToWorldMatrix
+        )}
+    } else {null}
+
     fun register() {
         REGISTRY.register()
     }

--- a/common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/entries/patterns/spells/moreiotas_interop.json
+++ b/common/src/main/resources/assets/hexcasting/patchouli_books/thehexbook/en_us/entries/patterns/spells/moreiotas_interop.json
@@ -1,0 +1,47 @@
+{
+  "name": "hexsky.entry.ship_moreiotas",
+  "category": "hexcasting:patterns/spells",
+  "icon": "minecraft:bamboo_boat",
+  "flag": "mod:moreiotas",
+  "sortnum": 10,
+  "advancement": "hexcasting:root",
+  "read_by_default": true,
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "hexsky.entry.ship_moreiotas.entry"
+    },
+    {
+      "type": "hexcasting:pattern",
+      "op_id": "hexsky:ship_slug_get",
+      "anchor": "hexsky:ship_slug_get",
+      "input": "ship",
+      "output": "string | null",
+      "text": "hexsky.page.ship_moreiotas.ship_slug_get"
+    },
+    {
+      "type": "hexcasting:pattern",
+      "op_id": "hexsky:ship_slug_set",
+      "anchor": "hexsky:ship_slug_set",
+      "input": "ship, string",
+      "output": "ship | null",
+      "text": "hexsky.page.ship_moreiotas.ship_slug_set"
+    },
+    {
+      "type": "hexcasting:pattern",
+      "op_id": "hexsky:world_to_ship_matrix",
+      "anchor": "hexsky:world_to_ship_matrix",
+      "input": "ship",
+      "output": "matrix",
+      "text": "hexsky.page.ship_moreiotas.world_to_ship_matrix"
+    },
+    {
+      "type": "hexcasting:pattern",
+      "op_id": "hexsky:ship_to_world_matrix",
+      "anchor": "hexsky:ship_to_world_matrix",
+      "input": "ship",
+      "output": "matrix",
+      "text": "hexsky.page.ship_moreiotas.ship_to_world_matrix"
+    }
+  ]
+}

--- a/common/src/main/resources/assets/hexsky/lang/en_us.json
+++ b/common/src/main/resources/assets/hexsky/lang/en_us.json
@@ -59,6 +59,17 @@
   "hexcasting.action.hexsky:disembark": "Disembark",
   "hexsky.page.ship_wisp.disembark": "has the wisp detach from the ship and go back into the world",
 
+  "hexsky.entry.ship_moreiotas": "MoreIotas ship spells",
+  "hexsky.entry.ship_moreiotas.entry": "with this influx of new iotas, i have been able to tap deeper into these strange constructs.$(br)i wonder what happens if i delve even further...",
+  "hexcasting.action.hexsky:ship_slug_get": "Boatwright's Prfn.",
+  "hexsky.page.ship_moreiotas.ship_slug_get": "gets the slug of the targeted ship",
+  "hexcasting.action.hexsky:ship_slug_set": "Boatwright's Dstl.",
+  "hexsky.page.ship_moreiotas.ship_slug_set": "sets the slug of the targeted ship if it is not cloaked",
+  "hexcasting.action.hexsky:world_to_ship_matrix": "Windward Purification",
+  "hexsky.page.ship_moreiotas.world_to_ship_matrix": "gets the $(thing)World-to-Ship$() transform matrix of the targeted ship",
+  "hexcasting.action.hexsky:ship_to_world_matrix": "Leeward Purification",
+  "hexsky.page.ship_moreiotas.ship_to_world_matrix": "gets the $(thing)Ship-to-World$() transform matrix of the targeted ship",
+
   "hexcasting.action.hexsky:shiptoworldpos": "Worldly Purification",
   "hexsky.page.ship_spells.shiptoworldpos": "Turns a posisition on a ship into a posisition in the world. does nothing if the point is allready in the world"
 }


### PR DESCRIPTION
### Patterns
- **Boatwright's Prfn.**
 - *Grabs the Ship's slug and adds it to the stack*
- **Boatwright's Dstl.**
 - *Takes a String and a Ship and sets the Ship's slug to that string and adds the Ship back to the stack*
- **Windward Purification**
 - *Grabs the World-To-Ship matrix and adds it to the stack*
- **Leeward Purification Added their Patchloui entries**
 - *Grasb the Ship-To-World matrix and adds it to the stack*
 
Added *org.jblas* and *MoreIotas* to `build.gradle`
*org.jblas* was needed for the `DoubleMatrix` that the `MatrixIota` took